### PR TITLE
Remove server code to substitute client secrets in index.html

### DIFF
--- a/signin.rb
+++ b/signin.rb
@@ -153,7 +153,6 @@ get '/' do
   response = File.read('index.html')
       .sub(/[{]{2}\s*STATE\s*[}]{2}/, state)
       .sub(/[{]{2}\s*CLIENT_ID\s*[}]{2}/, $credentials.client_id)
-      .sub(/[{]{2}\s*CLIENT_SECRET\s*[}]{2}/, $credentials.client_secret)
       .sub(/[{]{2}\s*APPLICATION_NAME\s*[}]{2}/, APPLICATION_NAME)
 end
 


### PR DESCRIPTION
@gguuss please review this pull request.

Removing client secret substitution when the server delivers the index.html file. It isn't being used, and if it were used would be a security leak (don't give away your client secret!).
