### PR TITLE
Fix to address kend issues in Ruby 1.8.7

### DIFF
--- a/signin.rb
+++ b/signin.rb
@@ -152,8 +152,6 @@ get '/' do
 
   response = File.read('index.html').sub(/[{]{2}\s*STATE\s*[}]{2}/, state)
   response = response.sub(/[{]{2}\s*CLIENT_ID\s*[}]{2}/, $credentials.client_id)
-  response = response.sub(/[{]{2}\s*CLIENT_SECRET\s*[}]{2}/, 
-      $credentials.client_secret)
   response = response.sub(/[{]{2}\s*APPLICATION_NAME\s*[}]{2}/, 
       APPLICATION_NAME)
 end

--- a/signin.rb
+++ b/signin.rb
@@ -150,11 +150,12 @@ get '/' do
   end
   state = session[:state]
 
-  response = File.read('index.html')
-      .sub(/[{]{2}\s*STATE\s*[}]{2}/, state)
-      .sub(/[{]{2}\s*CLIENT_ID\s*[}]{2}/, $credentials.client_id)
-      .sub(/[{]{2}\s*CLIENT_SECRET\s*[}]{2}/, $credentials.client_secret)
-      .sub(/[{]{2}\s*APPLICATION_NAME\s*[}]{2}/, APPLICATION_NAME)
+  response = File.read('index.html').sub(/[{]{2}\s*STATE\s*[}]{2}/, state)
+  response = response.sub(/[{]{2}\s*CLIENT_ID\s*[}]{2}/, $credentials.client_id)
+  response = response.sub(/[{]{2}\s*CLIENT_SECRET\s*[}]{2}/, 
+      $credentials.client_secret)
+  response = response.sub(/[{]{2}\s*APPLICATION_NAME\s*[}]{2}/, 
+      APPLICATION_NAME)
 end
 
 


### PR DESCRIPTION
The template substitution calls were causing issues on Ruby 1.8.7, moving them to separate lines.
